### PR TITLE
Moved cleardown up due to memory full issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ESP8266-TMP102
+# ESP8266-DS18B20
 
 Read the temperature from a DS18B20 sensor and publish it to an HTTP server over WiFi.
 

--- a/httppost.lua
+++ b/httppost.lua
@@ -31,11 +31,11 @@ if (Temperature < 85 ) then
       end)
   conn:connect(HTTPPORT,HTTPHOST)
 
-  conn:on("disconnection", function(conn)
                         t=nil
                         Temperature=nil
                         ds18b20 = nil
                         package.loaded["ds18b20"]=nil
+  conn:on("disconnection", function(conn)
                         print("Got disconnection...")
                         print ("Deep sleep...")
                         node.dsleep(MICROSECS);


### PR DESCRIPTION
if http disconnect does not occur loop continues without memory cleardown resulting in memory full error. moved the clearing of variables outside the disconnect function to ensure clearing whether a disconnect is received or not.
addnig print(node.heap()) temporarily above the disconnect function which showed the memory reducing.
